### PR TITLE
fix(admin): use verified CF Access email for git committer

### DIFF
--- a/internal/glance/admin.go
+++ b/internal/glance/admin.go
@@ -105,11 +105,13 @@ func (a *adminServer) middleware(next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// Layer 1: CF Access JWT (skipped in dev bypass).
 		if !a.devBypass {
-			if _, err := a.cfAccess.verifyFromRequest(r); err != nil {
+			email, err := a.cfAccess.verifyFromRequest(r)
+			if err != nil {
 				w.Header().Set("X-Admin-Auth-Failed", "cloudflare-access")
 				w.WriteHeader(http.StatusUnauthorized)
 				return
 			}
+			r = r.WithContext(withVerifiedEmail(r.Context(), email))
 		}
 
 		// Layer 2: Glance session cookie.
@@ -399,19 +401,32 @@ func (a *adminServer) handleConfigGeneration(w http.ResponseWriter, r *http.Requ
 }
 
 func committerFromRequest(r *http.Request) gitCommitter {
+	// Trust the email plumbed through context by the CF Access middleware.
+	// Cf-Access-* headers on the request are attacker-controllable if CF
+	// Access is bypassed at the edge, so we never use them for attribution
+	// when a verified email is available.
+	if email, ok := verifiedEmailFromContext(r.Context()); ok {
+		return gitCommitter{Email: email, Name: nameFromEmail(email)}
+	}
+
+	// Fallback for the dev-bypass path: no JWT was verified, so the caller
+	// is providing identity directly via headers.
 	email := r.Header.Get("Cf-Access-Email")
 	name := r.Header.Get("Cf-Access-Name")
 	if email == "" {
 		email = "admin@glance.local"
 	}
 	if name == "" {
-		if at := strings.Index(email, "@"); at > 0 {
-			name = email[:at]
-		} else {
-			name = "Glance Admin"
-		}
+		name = nameFromEmail(email)
 	}
 	return gitCommitter{Email: email, Name: name}
+}
+
+func nameFromEmail(email string) string {
+	if at := strings.Index(email, "@"); at > 0 {
+		return email[:at]
+	}
+	return "Glance Admin"
 }
 
 func (a *adminServer) handleHistoryList(w http.ResponseWriter, r *http.Request) {

--- a/internal/glance/admin_cfaccess.go
+++ b/internal/glance/admin_cfaccess.go
@@ -92,3 +92,19 @@ func (v *cfAccessVerifier) verifyFromRequest(r *http.Request) (email string, err
 	}
 	return v.verify(r.Context(), tok)
 }
+
+// verifiedEmailKey is the unexported context key under which the middleware
+// stashes the email extracted from a verified Cf-Access-Jwt-Assertion. Reading
+// from context is the only trustworthy way to learn the caller's identity;
+// raw Cf-Access-* headers are attacker-controllable if CF Access is ever
+// bypassed at the network edge.
+type verifiedEmailKey struct{}
+
+func withVerifiedEmail(ctx context.Context, email string) context.Context {
+	return context.WithValue(ctx, verifiedEmailKey{}, email)
+}
+
+func verifiedEmailFromContext(ctx context.Context) (string, bool) {
+	email, ok := ctx.Value(verifiedEmailKey{}).(string)
+	return email, ok && email != ""
+}

--- a/internal/glance/admin_committer_test.go
+++ b/internal/glance/admin_committer_test.go
@@ -1,0 +1,76 @@
+package glance
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestCommitterFromRequest_PrefersVerifiedContextOverHeaders(t *testing.T) {
+	req := httptest.NewRequest("PUT", "/admin/api/files/x", nil)
+	req.Header.Set("Cf-Access-Email", "attacker@evil.example")
+	req.Header.Set("Cf-Access-Name", "Mallory")
+	req = req.WithContext(withVerifiedEmail(req.Context(), "real@example.com"))
+
+	got := committerFromRequest(req)
+	if got.Email != "real@example.com" {
+		t.Fatalf("email: got %q, want verified value (not the spoofed header)", got.Email)
+	}
+	if got.Name != "real" {
+		t.Fatalf("name: got %q, want %q (derived from verified email, not the spoofed header)", got.Name, "real")
+	}
+}
+
+func TestCommitterFromRequest_FallsBackToHeadersWhenNoContext(t *testing.T) {
+	req := httptest.NewRequest("PUT", "/admin/api/files/x", nil)
+	req.Header.Set("Cf-Access-Email", "dev@example.com")
+	req.Header.Set("Cf-Access-Name", "Dev User")
+
+	got := committerFromRequest(req)
+	if got.Email != "dev@example.com" {
+		t.Fatalf("email: got %q, want %q", got.Email, "dev@example.com")
+	}
+	if got.Name != "Dev User" {
+		t.Fatalf("name: got %q, want %q", got.Name, "Dev User")
+	}
+}
+
+func TestCommitterFromRequest_DefaultsWhenNothingProvided(t *testing.T) {
+	req := httptest.NewRequest("PUT", "/admin/api/files/x", nil)
+
+	got := committerFromRequest(req)
+	if got.Email != "admin@glance.local" {
+		t.Fatalf("email: got %q, want default", got.Email)
+	}
+	if got.Name != "admin" {
+		t.Fatalf("name: got %q, want %q", got.Name, "admin")
+	}
+}
+
+func TestAdminMiddleware_StashesVerifiedEmailInContext(t *testing.T) {
+	a, _, signer, aud := newTestAdminServer(t)
+	a.liveApp = func() *application { return &application{} }
+
+	var seenEmail string
+	var seenOK bool
+	handler := a.middleware(func(w http.ResponseWriter, r *http.Request) {
+		seenEmail, seenOK = verifiedEmailFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest("GET", "/admin/anywhere", nil)
+	req.Header.Set("Cf-Access-Jwt-Assertion", mintToken(t, signer, aud, "you@example.com", time.Now().Add(time.Hour)))
+	rw := httptest.NewRecorder()
+	handler(rw, req)
+
+	if rw.Code == http.StatusUnauthorized && rw.Header().Get("X-Admin-Auth-Failed") != "session" {
+		t.Fatalf("CF Access layer rejected the request: %d / %s", rw.Code, rw.Header().Get("X-Admin-Auth-Failed"))
+	}
+	if !seenOK {
+		t.Fatalf("verified email not found in request context")
+	}
+	if seenEmail != "you@example.com" {
+		t.Fatalf("verified email: got %q, want %q", seenEmail, "you@example.com")
+	}
+}


### PR DESCRIPTION
## Summary
- Plumb the verified email returned by `cfAccessVerifier.verifyFromRequest` through `context.Context` so `committerFromRequest` no longer trusts spoofable `Cf-Access-Email` / `Cf-Access-Name` request headers for git commit attribution.
- Headers remain the fallback only on the dev-bypass path (no verifier runs there). The display name is derived from the verified email's local part rather than read from `Cf-Access-Name`, since that header is just as forgeable as the email one.

## Why
`(*adminServer).middleware` already verifies the CF Access JWT but discards the resulting email (`_, err := a.cfAccess.verifyFromRequest(r)`), and `committerFromRequest` then reads identity from the raw headers. This is **not** an auth bypass — the caller still needs a valid Glance session — but if CF Access is ever bypassed at the network edge (proxy misconfig, direct connection, `GLANCE_ADMIN_DEV_BYPASS=1`), an attacker with a session can spoof attribution on every git commit. That weakens history's value for compliance and postmortems.

Flagged by `silent-failure-hunter` during the [#5](https://github.com/schmug/glance/pull/5) self-review and explicitly deferred to keep that PR focused on correctness bugs.

## Test plan
- [x] New unit tests in `internal/glance/admin_committer_test.go`:
  - `TestCommitterFromRequest_PrefersVerifiedContextOverHeaders` — context wins over spoofed headers
  - `TestCommitterFromRequest_FallsBackToHeadersWhenNoContext` — dev-bypass path still works
  - `TestCommitterFromRequest_DefaultsWhenNothingProvided` — default identity unchanged
  - `TestAdminMiddleware_StashesVerifiedEmailInContext` — middleware actually plumbs the value
- [x] `go test ./...` green
- [x] `go build ./...` green
- [x] Grepped for any other place `Cf-Access-*` headers are trusted for identity — only the dev-bypass fallback remains

🤖 Generated with [Claude Code](https://claude.com/claude-code)