### PR TITLE
Docker Compose + Cloudflare Tunnel deploy stack, plus Dockerfile Go 1.25 fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.3-alpine3.21 AS builder
+FROM golang:1.25-alpine3.21 AS builder
 
 WORKDIR /app
 COPY . /app

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -1,0 +1,5 @@
+# Cloudflare Tunnel token from: Zero Trust > Networks > Tunnels > <your tunnel> > Install connector
+TUNNEL_TOKEN=
+
+# Optional: override timezone
+TZ=UTC

--- a/deploy/.gitignore
+++ b/deploy/.gitignore
@@ -1,0 +1,2 @@
+.env
+config/.glance-history/

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,70 @@
+# Glance + Cloudflare Tunnel (Docker Compose)
+
+One-command deployment of Glance behind a Cloudflare Tunnel with Cloudflare Access in front of `/admin`.
+
+## Prerequisites
+
+- Docker + Docker Compose
+- A Cloudflare account with a zone you control
+- A Cloudflare Tunnel created in Zero Trust → Networks → Tunnels (save the install token)
+- A Cloudflare Access application protecting your hostname (save the AUD tag)
+
+## First-time setup
+
+1. Copy env template:
+   ```
+   cp .env.example .env
+   ```
+   Paste your tunnel token into `TUNNEL_TOKEN`.
+
+2. Build the image (required for the `secret:make` / `password:hash` helpers below):
+   ```
+   docker compose build
+   ```
+
+3. Generate a session secret and a password hash, paste both into `config/glance.yml`:
+   ```
+   docker compose run --rm glance /app/glance secret:make
+   docker compose run --rm glance /app/glance password:hash 'your-password-here'
+   ```
+
+4. Edit `config/glance.yml`:
+   - `auth.secret-key` ← generated secret
+   - `auth.users.admin.password-hash` ← generated hash
+   - `admin.cloudflare-access.team-domain` ← `YOURTEAM.cloudflareaccess.com`
+   - `admin.cloudflare-access.audience` ← AUD tag from the Access app
+   - `admin.cloudflare-access.allowed-emails` ← your email(s)
+
+5. In the Cloudflare Tunnel dashboard, add a public hostname routing your domain to `http://glance:8080`.
+
+6. Bring it up:
+   ```
+   docker compose up -d
+   docker compose logs -f
+   ```
+
+Visit your hostname → you'll be gated by Access, then Glance session login, then land on the dashboard. `/admin` works the same.
+
+## Local bring-up without Cloudflare
+
+For first-run smoke tests before the tunnel is wired up:
+
+1. In `docker-compose.yml`, uncomment the `ports: 8080:8080` mapping on the `glance` service.
+2. In `docker-compose.yml`, uncomment `GLANCE_ADMIN_DEV_BYPASS: "1"` to skip CF Access verification (session login still required).
+3. Remove or comment out the `cloudflared` service (or `docker compose up glance`).
+4. Browse `http://localhost:8080`.
+
+Re-enable both before exposing publicly.
+
+## Persistence
+
+- `./config/glance.yml` is the live, editable config. The `/admin` UI writes here.
+- `./config/.glance-history/` is a local-only git repo of every config change. Do not commit.
+
+## Updating
+
+```
+docker compose pull cloudflared
+docker compose build glance
+docker compose up -d
+```

--- a/deploy/config/glance.yml
+++ b/deploy/config/glance.yml
@@ -1,0 +1,34 @@
+server:
+  host: 0.0.0.0
+  port: 8080
+  proxied: true
+
+auth:
+  # Generate with: docker run --rm glance:local /app/glance secret:make
+  secret-key: REPLACE_WITH_GENERATED_SECRET
+  users:
+    admin:
+      # Generate with: docker run --rm glance:local /app/glance password:hash <password>
+      password-hash: REPLACE_WITH_BCRYPT_HASH
+
+admin:
+  enabled: true
+  history-dir: ./.glance-history
+  cloudflare-access:
+    team-domain: YOUR_TEAM.cloudflareaccess.com
+    audience: YOUR_CF_ACCESS_APP_AUD_TAG
+    allowed-emails:
+      - you@example.com
+
+theme:
+  preset: default
+
+pages:
+  - name: Home
+    columns:
+      - size: full
+        widgets:
+          - type: markdown
+            content: |
+              # Welcome to Glance
+              Edit this config at `/admin`.

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,0 +1,28 @@
+services:
+  glance:
+    build:
+      context: ..
+      dockerfile: Dockerfile
+    image: glance:local
+    restart: unless-stopped
+    volumes:
+      - ./config:/app/config
+    environment:
+      # Uncomment for local testing without Cloudflare Access.
+      # Requires a valid Glance session (password) regardless.
+      # GLANCE_ADMIN_DEV_BYPASS: "1"
+      TZ: ${TZ:-UTC}
+    expose:
+      - "8080"
+    # Uncomment to reach glance directly during bring-up (bypassing the tunnel).
+    # ports:
+    #   - "8080:8080"
+
+  cloudflared:
+    image: cloudflare/cloudflared:latest
+    restart: unless-stopped
+    command: tunnel --no-autoupdate run
+    environment:
+      TUNNEL_TOKEN: ${TUNNEL_TOKEN:?set TUNNEL_TOKEN in .env}
+    depends_on:
+      - glance


### PR DESCRIPTION
## Summary
- Fix Dockerfile builder: `golang:1.24.3-alpine3.21` → `golang:1.25-alpine3.21` so image builds succeed (go.mod already requires Go ≥1.25).
- Add `deploy/` stack: `docker-compose.yml` running `glance` + `cloudflared` siblings, a template `config/glance.yml` with the admin block + CF Access placeholders, `.env.example`, and a README covering first-time setup and a local smoke-test path.

Design notes:
- `glance` container does not publish a port — the Cloudflare Tunnel is the only ingress.
- Single bind mount holds both `glance.yml` and `.glance-history/` so `/admin` edits persist across restarts.
- cloudflared reaches glance via compose DNS (`http://glance:8080`); the public hostname mapping lives in the CF Tunnel dashboard.

## Test plan
- [ ] `docker compose -f deploy/docker-compose.yml build` succeeds
- [ ] Local bring-up path (uncomment ports + `GLANCE_ADMIN_DEV_BYPASS=1`, omit `cloudflared`): `/` and `/admin` reachable on `localhost:8080`
- [ ] Full path with a real tunnel token + CF Access app: public hostname is gated by Access, then Glance session login, then dashboard; `/admin` works and saved edits appear in `./config/.glance-history/`
- [ ] `docker compose down && docker compose up -d` — edits and history persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)