### PR TITLE
Live theme customization in the picker

### DIFF
--- a/internal/glance/static/js/page.js
+++ b/internal/glance/static/js/page.js
@@ -856,9 +856,10 @@ function setupThemeCustomize() {
     syncCustomizeUI(initial);
 
     document.addEventListener("pointerdown", (e) => {
-        const input = e.target.closest(".theme-customize-input");
-        if (!input) return;
-        keepPopoverAliveWhile(input);
+        const swatch = e.target.closest(".theme-customize-swatch");
+        if (!swatch) return;
+        const input = swatch.querySelector(".theme-customize-input");
+        if (input) keepPopoverAliveWhile(input);
     });
 
     document.addEventListener("input", (e) => {
@@ -913,6 +914,7 @@ function keepPopoverAliveWhile(input) {
     }
 
     input.addEventListener("change", stop, { once: true });
+    input.addEventListener("cancel", stop, { once: true });
     input.addEventListener("blur", stop, { once: true });
 }
 


### PR DESCRIPTION
## Summary

Adds an interactive **Customize** panel to the existing theme picker (top-right popover) so a user can:

- Click a **Background** swatch and pick any color via the native browser color picker. The widget background, separators, popover surfaces, and text tones autocalc from the new background HSL via the existing `calc()` math in `main.css` — no extra plumbing.
- Click a **Text** swatch to override `--color-primary` (and `--color-positive`) live.
- Hit **Reset** to drop the customization and snap back to the active preset.
- Hit **Copy YAML** to drop a paste-ready preset block onto the clipboard, e.g.:
  ```yaml
  # paste under theme.presets in glance.yml
    my-custom:
      background-color: 240 8 9
      primary-color: 43 50 70
  ```

State persists in `localStorage` (`glance-custom-theme`). An inline `<script>` in `document.html` restores it pre-paint to avoid FOUC. Switching to any preset clears the customize layer for an intuitive "fresh start." Background lightness > 50% auto-flips `data-scheme` to `light`.

## Why

The existing theme system already centralizes everything in CSS custom properties, so a per-user live override is a tiny addition that unlocks a lot of personalization without expanding the YAML config surface or adding a server round-trip. Power users can still promote their tweak into the canonical config via Copy YAML.

## Files changed

- `internal/glance/templates/page.html` — Customize panel UI inside the popover; wraps it and the existing `.theme-choices` in a `.theme-popover-content` container so both halves get cloned to the header copy
- `internal/glance/templates/document.html` — pre-paint inline script that restores saved state from `localStorage` before first paint
- `internal/glance/static/js/page.js` — hex→HSL conversion, localStorage persistence, YAML formatter, popover keep-alive while the OS color dialog is open, preset-click clears custom state
- `internal/glance/static/css/site.css` — styling for the customize panel (swatches, buttons, separator)

## Notes for reviewers

- "Text" swatch maps to `--color-primary` (accents/links), not body text. Body text is derived from background hue via the existing `--ths` math, so changing the background does shift body text appropriately. Independent body-text override would require one new CSS var in `main.css` — out of scope here.
- The header theme picker uses hover-trigger ([popover.js](internal/glance/static/js/popover.js)). When the OS color dialog opens, the cursor leaves the popover bounds and the 500ms hide timer would dismiss it before the user could pick. The fix in `keepPopoverAliveWhile()` dispatches synthetic `mouseenter` events on `.popover-container` every 100ms while a swatch input is active, stopping on `change`/`cancel`/`blur` or a 60s safety timeout. This avoids touching the popover module itself.
- The pre-paint script in `document.html` intentionally duplicates the hex→HSL math from `page.js`. They share the `glance-custom-theme` storage key.
- localStorage is per-browser-profile, not synced across devices — by design for this iteration.

## Test plan

- [ ] Open the dashboard, click the theme picker. Customize panel appears below the presets.
- [ ] Click the **Background** swatch, drag through colors in the native picker. Page background, widget surfaces, and text tones all update in real time.
- [ ] Click the **Text** swatch. Accent color (links, header text) updates live.
- [ ] Set background to a light color (e.g. `#f0f0f0`). Verify `<html data-scheme="light">` flips and the UI uses the light scheme.
- [ ] Click **Copy YAML**. Paste it under `theme.presets` in `glance.yml`, restart, and verify the preset renders identically.
- [ ] Reload. Custom theme persists with no flash of default theme.
- [ ] Click **Reset**. Page reloads onto the active preset; localStorage is cleared.
- [ ] Click any built-in preset. Customize layer clears automatically.
- [ ] Verify the popover stays open for the duration of color picking (regression: it was dismissing mid-pick before the keep-alive fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)